### PR TITLE
Add footerSocials

### DIFF
--- a/docs/mint.config.json
+++ b/docs/mint.config.json
@@ -84,5 +84,9 @@
         "api-reference/update-charge"
       ]
     }
-  ]
+  ],
+  "footerSocials": {
+    "website": "https://www.corrily.com",
+    "twitter": "https://twitter.com/usecorrily"
+  }
 }

--- a/docs/mint.config.json
+++ b/docs/mint.config.json
@@ -87,6 +87,7 @@
   ],
   "footerSocials": {
     "website": "https://www.corrily.com",
-    "twitter": "https://twitter.com/usecorrily"
+    "twitter": "https://twitter.com/usecorrily",
+    "linkedin": "https://www.linkedin.com/company/corrily"
   }
 }


### PR DESCRIPTION
# Summary
This PR adds social icons at the footer to link the documentation with the Corrily website, Twitter, and LinkedIn (for better SEO and user flow)

<img width="162" alt="Screen Shot 2022-08-26 at 5 04 51 PM" src="https://user-images.githubusercontent.com/44352119/187005864-67cb8585-1500-476f-92a1-824d285b515d.png">

