### PR TITLE
Fix invalid JSON requests

### DIFF
--- a/docs/api-reference/create-product.mdx
+++ b/docs/api-reference/create-product.mdx
@@ -38,43 +38,43 @@ curl --location -g --request POST 'https://client.corrily.com/v1/products' \
 </RequestExample>
 
 <ResponseExample>
+
 ```json Example
 {
-   "message": "Successfully created product.",
-   "success": true,
-   "api_id": "monthly",
-   "name": "Monthly Product",
-   "base_px": 10.0,
-   "max_px": 999.0,
-   "min_px": 0.0,
-   "baseline_id": null,
-   "country_prices": [
-      {
-         "country": "ES",
-         "local_price": 50.0,
-         "currency": "EUR"
-      }
-   ],
-   "integrations": [
-      {
-         "id": 87,
-         "org": 170,
-         "product_id": 1189,
-         "stripe_price_id": null,
-         "stripe_product_id": "my_stripe_pid",
-         "interval": null,
-         "interval_count": null,
-         "created_at": "2022-09-07T12:54:46.031057+00:00",
-         "updated_at": "2022-09-07T12:54:46.031057+00:00"
-      }
-   ]
+  "message": "Successfully created product.",
+  "success": true,
+  "api_id": "monthly",
+  "name": "Monthly Product",
+  "base_px": 10.0,
+  "max_px": 999.0,
+  "min_px": 0.0,
+  "baseline_id": null,
+  "country_prices": [
+    {
+      "country": "ES",
+      "local_price": 50.0,
+      "currency": "EUR"
+    }
+  ],
+  "integrations": [
+    {
+      "id": 87,
+      "org": 170,
+      "product_id": 1189,
+      "stripe_price_id": null,
+      "stripe_product_id": "my_stripe_pid",
+      "interval": null,
+      "interval_count": null,
+      "created_at": "2022-09-07T12:54:46.031057+00:00",
+      "updated_at": "2022-09-07T12:54:46.031057+00:00"
+    }
+  ]
 }
 ```
+
 </ResponseExample>
 
 ## Body Params
-
-
 
 <Param body="name" type="string" required>
 
@@ -100,4 +100,3 @@ An integer denoting how many intervals to bill for the. A monthly product would 
 One time products should have an interval count of `1`.
 
 </Param>
-

--- a/docs/api-reference/get-product.mdx
+++ b/docs/api-reference/get-product.mdx
@@ -15,38 +15,40 @@ curl --location --request GET 'https://default.corrily.com/mainapi/v1/products/m
 </RequestExample>
 
 <ResponseExample>
+
 ```json Example
 {
-   "message": "Successfully created product.",
-   "success": true,
-   "api_id": "monthly",
-   "name": "Monthly Product",
-   "base_px": 10.0,
-   "max_px": 999.0,
-   "min_px": 0.0,
-   "baseline_id": null,
-   "country_prices": [
-      {
-         "country": "ES",
-         "local_price": 50.0,
-         "currency": "EUR"
-      }
-   ],
-   "integrations": [
-      {
-         "id": 87,
-         "org": 170,
-         "product_id": 1189,
-         "stripe_price_id": null,
-         "stripe_product_id": "my_stripe_pid",
-         "interval": null,
-         "interval_count": null,
-         "created_at": "2022-09-07T12:54:46.031057+00:00",
-         "updated_at": "2022-09-07T12:54:46.031057+00:00"
-      }
-   ]
+  "message": "Successfully created product.",
+  "success": true,
+  "api_id": "monthly",
+  "name": "Monthly Product",
+  "base_px": 10.0,
+  "max_px": 999.0,
+  "min_px": 0.0,
+  "baseline_id": null,
+  "country_prices": [
+    {
+      "country": "ES",
+      "local_price": 50.0,
+      "currency": "EUR"
+    }
+  ],
+  "integrations": [
+    {
+      "id": 87,
+      "org": 170,
+      "product_id": 1189,
+      "stripe_price_id": null,
+      "stripe_product_id": "my_stripe_pid",
+      "interval": null,
+      "interval_count": null,
+      "created_at": "2022-09-07T12:54:46.031057+00:00",
+      "updated_at": "2022-09-07T12:54:46.031057+00:00"
+    }
+  ]
 }
 ```
+
 </ResponseExample>
 
 ## Path Params


### PR DESCRIPTION
### Summary
Currently when using the `<ResponseExample>` or `<RequestExample>` components, you need to add a line before and after the code blocks. This is a bug that we are working around the clock to address systematically (ETA 1 week).

Apologies for the confusion