### PR TITLE
Support markdown in response fields

### DIFF
--- a/docs/api-reference/update-product.mdx
+++ b/docs/api-reference/update-product.mdx
@@ -71,7 +71,7 @@ One time products should have an interval count of `1`.
 
 <Param body="country_prices" type="[object]">
 
-A list of one ore more of the below country price object. *Country prices provided during an update call with overwrite any existing ones*.
+A list of one ore more of the below country price object. _Country prices provided during an update call with overwrite any existing ones_.
 
 <Expandable title="<country_price>">
     <ResponseField name="country" type="string" required>
@@ -86,68 +86,83 @@ A list of one ore more of the below country price object. *Country prices provid
 
 </Expandable>
 
-
 </Param>
-
 
 <Param body="integrations" type="[object]">
 
-A list of one or more of the below integration price objects. *Integration objects provided during an update call with overwrite any existing ones*.
+A list of one or more of the below integration price objects. _Integration objects provided during an update call with overwrite any existing ones_.
 
 <Expandable title="<stripe>">
-    <Param body="type" type="string" required>
-        Should be set to equal `stripe`.
-    </Param>
-    <Param body="stripe_product_id" type="stripe" required>
-        The matching [Stripe product ID](https://stripe.com/docs/api/products/object#product_object-id).
-    </Param>
+    <ResponseField body="type" type="string" required>
+
+    Should be set to equal `stripe`.
+
+    </ResponseField>
+    <ResponseField body="stripe_product_id" type="stripe" required>
+
+    The matching [Stripe product ID](https://stripe.com/docs/api/products/object#product_object-id).
+
+    <ResponseField>
 
 </Expandable>
 
 <Expandable title="<stripe_with_interval>">
     <ResponseField name="type" type="string" required>
-        Should be set to equal `stripe_with_interval`.
+    
+    Should be set to equal `stripe_with_interval`.
+
     </ResponseField>
     <ResponseField name="stripe_product_id" type="string" required>
-        The matching [Stripe product ID](https://stripe.com/docs/api/products/object#product_object-id).
+
+    The matching [Stripe product ID](https://stripe.com/docs/api/products/object#product_object-id).
+
     </ResponseField>
     <ResponseField name="interval" type="enum" required>
-        The frequency at which a subscription is billed. One of `day`, `week`, `month` or `year`.
-        Sometimes Stripe products actually encompass more than what Corrily would consider a product. For example,
-        the Stripe product for a company's "Pro Plan" might have two
-        [Price objects](https://stripe.com/docs/api/prices/object)
-        one for the monthly version of the plan, the other for its annual version. Meanwhile, Corrily would consider
-        these to be two distinct products `pro_monthly` and `pro_annual`. To capture such differences you can pass
-        a `stripe_with_interval` integration object which can help separate such cases.
+
+    The frequency at which a subscription is billed. One of `day`, `week`, `month` or `year`.
+    Sometimes Stripe products actually encompass more than what Corrily would consider a product. For example,
+    the Stripe product for a company's "Pro Plan" might have two
+    [Price objects](https://stripe.com/docs/api/prices/object)
+    one for the monthly version of the plan, the other for its annual version. Meanwhile, Corrily would consider
+    these to be two distinct products `pro_monthly` and `pro_annual`. To capture such differences you can pass
+    a `stripe_with_interval` integration object which can help separate such cases.
+
     </ResponseField>
     <ResponseField name="interval_count" type="integer" required>
-        The number of intervals (specified in the interval attribute) between subscription billings.
-        For example, interval=month and interval_count=3 bills every 3 months.
+
+    The number of intervals (specified in the interval attribute) between subscription billings.
+    For example, interval=month and interval_count=3 bills every 3 months.
+
     </ResponseField>
 
 </Expandable>
 
 <Expandable title="<chargebee>">
     <ResponseField name="type" type="string" required>
-        Should be set to equal `chargebee`.
+    
+    Should be set to equal `chargebee`.
+
     </ResponseField>
     <ResponseField name="chargebee_plan_id" type="string" required>
-       The matching [Chargebee plan ID](https://apidocs.chargebee.com/docs/api/plans?prod_cat_ver=1#plan_id).
+
+    The matching [Chargebee plan ID](https://apidocs.chargebee.com/docs/api/plans?prod_cat_ver=1#plan_id).
+
     </ResponseField>
 
 </Expandable>
 
 <Expandable title="<recurly>">
     <ResponseField name="type" type="string" required>
-        Should be set to equal `recurly`.
+
+    Should be set to equal `recurly`.
+
     </ResponseField>
     <ResponseField name="chargebee_plan_id" type="string" required>
-        The matching [Recurly plan ID](https://developers.recurly.com/api/v2021-02-25/index.html#operation/create_plan).
+
+    The matching [Recurly plan ID](https://developers.recurly.com/api/v2021-02-25/index.html#operation/create_plan).
+
     </ResponseField>
 
 </Expandable>
 
 </Param>
-
-
-


### PR DESCRIPTION
### Summary

The fix is adding a line padding sandwich before and after the markdown content inside a component.
